### PR TITLE
## Correções desta Versão

### DIFF
--- a/sei/scripts/sei_atualizar_versao_modulo_correios.php
+++ b/sei/scripts/sei_atualizar_versao_modulo_correios.php
@@ -5,10 +5,10 @@ class MdCorAtualizadorSeiRN extends InfraRN
 {
 
     private $numSeg = 0;
-    private $versaoAtualDesteModulo = '2.1.0';
+    private $versaoAtualDesteModulo = '2.2.0';
     private $nomeDesteModulo = 'MÓDULO CORREIOS';
     private $nomeParametroModulo = 'VERSAO_MODULO_CORREIOS';
-    private $historicoVersoes = array('1.0.0', '2.0.0', '2.1.0');
+    private $historicoVersoes = array('1.0.0', '2.0.0', '2.1.0','2.2.0');
 
     public function __construct()
     {
@@ -114,6 +114,8 @@ class MdCorAtualizadorSeiRN extends InfraRN
                     $this->instalarv200();
                 case '2.0.0':
                     $this->instalarv210();
+	              case '2.1.0':
+	            	    $this->instalarv220();
                     break;
 
                 default:
@@ -1073,7 +1075,7 @@ class MdCorAtualizadorSeiRN extends InfraRN
         $this->logar('ADICIONANDO PARÂMETRO ' . $this->nomeParametroModulo . ' NA TABELA infra_parametro PARA CONTROLAR A VERSÃO DO MÓDULO');
         BancoSEI::getInstance()->executarSql('INSERT INTO infra_parametro (valor, nome) VALUES (\'1.0.0\' , \'' . $this->nomeParametroModulo . '\' ) ');
 
-        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO ' . $this->versaoAtualDesteModulo . ' DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SEI');
+        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO 1.0.0 DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SEI');
     }
 
 
@@ -1092,7 +1094,7 @@ class MdCorAtualizadorSeiRN extends InfraRN
         $this->logar('ATUALIZANDO PARÂMETRO ' . $this->nomeParametroModulo . ' NA TABELA infra_parametro PARA CONTROLAR A VERSÃO DO MÓDULO');
         BancoSEI::getInstance()->executarSql('UPDATE infra_parametro SET valor = \'2.0.0\' WHERE nome = \'' . $this->nomeParametroModulo . '\' ');
 
-        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO ' . $this->versaoAtualDesteModulo . ' DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SEI');
+        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO 2.0.0 DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SEI');
     }
 
     private function instalarv210()
@@ -1244,8 +1246,27 @@ ATENÇÃO: As informações contidas neste e-mail, incluindo seus anexos, podem ser 
         $this->logar('ATUALIZANDO PARÂMETRO ' . $this->nomeParametroModulo . ' NA TABELA infra_parametro PARA CONTROLAR A VERSÃO DO MÓDULO');
         BancoSEI::getInstance()->executarSql('UPDATE infra_parametro SET valor = \'2.1.0\' WHERE nome = \'' . $this->nomeParametroModulo . '\' ');
 
-        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO ' . $this->versaoAtualDesteModulo . ' DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SEI');
+        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO 2.1.0 DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SEI');
     }
+
+    protected function instalarv220(){
+	    $objInfraParametro = new InfraParametro(BancoSEI::getInstance());
+	    $this->logar('EXECUTANDO A INSTALAÇÃO/ATUALIZAÇÃO DA VERSAO 2.2.0 DO ' . $this->nomeDesteModulo . ' NA BASE DO SEI');
+
+	    $objInfraMetaBD = new InfraMetaBD(BancoSEI::getInstance());
+	    $objInfraMetaBD->setBolValidarIdentificador(true);
+
+	    $this->logar('ADICIONANDO A COLUNA sin_anexar_midia NA TABELA md_cor_servico_postal');
+	    $objInfraMetaBD->adicionarColuna('md_cor_servico_postal', 'sin_anexar_midia', $objInfraMetaBD->tipoTextoFixo(1), 'null');
+	    BancoSEI::getInstance()->executarSql("update md_cor_servico_postal set sin_anexar_midia = 'N'");
+	    $objInfraMetaBD->alterarColuna('md_cor_servico_postal', 'sin_anexar_midia', $objInfraMetaBD->tipoTextoFixo(1), 'not null');
+	    $this->logar('COLUNA sin_anexar_midia criada, valor atualizado para \'N\' e, posteriormente, modificada para NOT NULL');
+
+	    $this->logar('ATUALIZANDO PARÂMETRO ' . $this->nomeParametroModulo . ' NA TABELA infra_parametro PARA CONTROLAR A VERSÃO DO MÓDULO');
+	    BancoSEI::getInstance()->executarSql('UPDATE infra_parametro SET valor = \'2.2.0\' WHERE nome = \'' . $this->nomeParametroModulo . '\' ');
+
+	    $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO 2.2.0 DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SEI');
+		}
 
     protected function fixIndices(InfraMetaBD $objInfraMetaBD, $arrTabelas)
     {

--- a/sei/web/modulos/correios/CorreiosIntegracao.php
+++ b/sei/web/modulos/correios/CorreiosIntegracao.php
@@ -15,7 +15,7 @@ class CorreiosIntegracao extends SeiIntegracao
 
     public function getVersao()
     {
-        return '2.1.0';
+        return '2.2.0';
     }
 
     public function getInstituicao()
@@ -656,6 +656,28 @@ class CorreiosIntegracao extends SeiIntegracao
                     $xml = "<Resultado><Sucesso>N</Sucesso></Resultado>";
                 }
                 break;
+
+		        case 'md_cor_change_serv_postal':
+			          $xml = "<Documento>";
+		        	  if ( !empty( $_POST['idServPostal'] ) ) {
+				          $objDTO = MdCorServicoPostalINT::getInfoServicoPostalPorId( $_POST['idServPostal'] );
+				          if ( $objDTO ) {
+					          if ( $objDTO->getStrSinAnexarMidia() == 'S' ) {
+						          $xml .= "<Retorno>S</Retorno>";
+				            } else {
+						          $xml .= "<Retorno>N</Retorno>";
+					          }
+				          }
+			          }
+			          $xml .= "</Documento>";
+		    	      break;
+
+		        case 'md_cor_valida_arq_ext':
+		        	  $xml = "<Documento>";
+		        	  $xml .= MdCorServicoPostalINT::validaArqExt( $_POST );
+			          $xml .= "</Documento>";
+
+		        	  break;
         }
 
         return $xml;

--- a/sei/web/modulos/correios/dto/MdCorServicoPostalDTO.php
+++ b/sei/web/modulos/correios/dto/MdCorServicoPostalDTO.php
@@ -54,6 +54,10 @@ class MdCorServicoPostalDTO extends InfraDTO {
                                    'sin_servico_cobrar ');
 
     $this->adicionarAtributoTabela(InfraDTO::$PREFIXO_STR,
+                                    'SinAnexarMidia',
+                                    'sin_anexar_midia');
+
+    $this->adicionarAtributoTabela(InfraDTO::$PREFIXO_STR,
       'SinAtivo',
       'sin_ativo');
 

--- a/sei/web/modulos/correios/int/MdCorServicoPostalINT.php
+++ b/sei/web/modulos/correios/int/MdCorServicoPostalINT.php
@@ -86,5 +86,47 @@ class MdCorServicoPostalINT extends InfraINT {
         return parent::montarSelectArrInfraDTO($strPrimeiroItemValor, $strPrimeiroItemDescricao, $strValorItemSelecionado, $arrObjMdCorServicoPostalDTO, 'IdMdCorServicoPostal', 'Nome');
     }
 
+
+  public static function getInfoServicoPostalPorId( $id ){
+  	$objMdCorServicoPostalDTO = new MdCorServicoPostalDTO();
+	  $objMdCorServicoPostalRN  = new MdCorServicoPostalRN();
+
+	  $objMdCorServicoPostalDTO->setNumIdMdCorServicoPostal( $id );
+	  $objMdCorServicoPostalDTO->retStrSinAnexarMidia();
+	  $objMdCorServicoPostalDTO->retStrSinServicoCobrar();
+	  $objMdCorServicoPostalDTO->retStrNome();
+	  $objMdCorServicoPostalDTO->retStrDescricao();
+
+	  $objMdCorServicoPostalDTO = $objMdCorServicoPostalRN->consultar( $objMdCorServicoPostalDTO );
+
+	  return $objMdCorServicoPostalDTO;
+  }
+
+  public static function validaArqExt($arrParams){
+  	$arrIdsProt            = ( array_key_exists('arrIdsProt',$arrParams) && !empty( $arrParams['arrIdsProt'] ) )  ? $arrParams['arrIdsProt'] : null;
+	  $arrDescDoc            = ( array_key_exists('arrDescDoc',$arrParams ) && !empty( $arrParams['arrDescDoc'] ) ) ? $arrParams['arrDescDoc'] : null;
+	  $strPermiteGravarMidia = ( array_key_exists('strPermiteGravarMidia',$arrParams ) && !empty( $arrParams['strPermiteGravarMidia'] ) ) ? $arrParams['strPermiteGravarMidia'] : null;
+	  $arrExibir             = [];
+	  $arrNaoExibir          = [];
+
+	  foreach ( $arrIdsProt as $k => $prot ) {
+		  $somenteMidia = filter_var( MdCorExpedicaoSolicitadaProtocoloAnexoINT::verificarAnexoSomenteMidia($prot , false) ,FILTER_VALIDATE_BOOLEAN );
+
+		  if ( $strPermiteGravarMidia == 'N' ) {
+		  	if ( $somenteMidia ) {
+				  array_push($arrNaoExibir ,$prot.'#'.$arrDescDoc[$k] );
+			  } else {
+				  array_push($arrExibir ,$prot.'#'.$arrDescDoc[$k] );
+			  }
+		  } else {
+			  array_push($arrExibir ,$prot.'#'.$arrDescDoc[$k] );
+		  }
+	  }
+	  $strListaExibir    = '<Exibir>'.implode(';' ,$arrExibir ).'</Exibir>';
+	  $strListaNaoExibir = !empty($arrNaoExibir) ? '<NaoExibir>'.implode(';' ,$arrNaoExibir ).'</NaoExibir>' : '';
+
+	  return $strListaExibir . $strListaNaoExibir;
+  }
+
 }
 ?>

--- a/sei/web/modulos/correios/md_cor_contrato_cadastro.php
+++ b/sei/web/modulos/correios/md_cor_contrato_cadastro.php
@@ -156,6 +156,7 @@ try {
                 $sinAtivo[$i] = $objMdCorServicoPostalDTO->getStrSinAtivo();
 
                 $cobrar = $objMdCorServicoPostalDTO->getStrSinServicoCobrar();
+                $anexarMidia = $objMdCorServicoPostalDTO->getStrSinAnexarMidia();
                 $checked = ' checked="checked"';
                 $readonly = '';
                 if (($_GET['acao'] == 'md_cor_contrato_consultar')) {
@@ -164,6 +165,7 @@ try {
                 $checkedSim = ($ar == 'S') ? $checked : '';
                 $checkedNao = ($ar == 'N' && $objMdCorServicoPostalDTO->getStrSinAr() != 'N') ? $checked : '';
                 $checkedCobrar = ($cobrar == 'S') ? $checked : '';
+                $checkedAnexarMidia = ($anexarMidia == 'S') ? $checked : '';
                 $disabledSinAr = $objMdCorServicoPostalDTO->getStrSinAr() == 'N' ? 'disabled="disabled"' : null;
 
                 $strRd = '<div id="divRdoAr" class="infraDivRadio" align="center" style="width: 100%">';
@@ -192,16 +194,19 @@ try {
                 $strChk .= '    </div>';
                 $strChk .= '</div>';
 
+                $strAnexarMidia = '<div class="infraDivCheckbox" style="text-align: center"> <div class="infraCheckboxDiv"> <input type="checkbox" class="infraCheckboxInput" value="S" name="anexarMidia['.$i.']" id="anexarMidia['.$i.']" '. $checkedAnexarMidia . $readonly .'> <label class="infraCheckboxLabel" for="anexarMidia['.$i.']"></label> </div> </div>';
+
                 $itensTabelaContratoServicos = array(
                     $objMdCorServicoPostalDTO->getStrIdWsCorreios(),
                     $objMdCorServicoPostalDTO->getStrCodigoWsCorreios(),
                     $objMdCorServicoPostalDTO->getStrSinAtivo(),
                     '',
                     $objMdCorServicoPostalDTO->getStrNome(),
-                    '<div style="width:100px;"><select class="infraSelect sl_tipo form-control" name="sl_tipo[' . $i . ']"  onchange="verificaAr(this)">' . json_encode($mdCorTipoCorrespondencia) . '</select></div>',
-                    $strRd,
-                    $strChk,
-                    '<div style="width:130px"><input type="text" class="input-desc form-control" name="descricao[' . $i . ']" value="' . PaginaSEI::tratarHTML($objMdCorServicoPostalDTO->getStrDescricao()) . '" ' . $readonly . '/><input type="hidden" name="id[' . $i . ']" value="' . $objMdCorServicoPostalDTO->getStrIdWsCorreios() . '"><input class="input-desc" type="hidden" name="codigo[' . $i . ']" value="' . $objMdCorServicoPostalDTO->getStrCodigoWsCorreios() . '"><input class="input-desc" type="hidden" name="nome[' . $i . ']" value="' . $objMdCorServicoPostalDTO->getStrNome() . '"><input class="input-desc" type="hidden" value="' . $objMdCorServicoPostalDTO->getNumIdMdCorServicoPostal() . '"></div>',
+                    /*5*/'<div style="width:100px;"><select class="infraSelect sl_tipo form-control" name="sl_tipo[' . $i . ']"  onchange="verificaAr(this)">' . json_encode($mdCorTipoCorrespondencia) . '</select></div>',
+	                /*6*/$strRd,
+	                /*7*/$strChk,
+	                $strAnexarMidia,
+                    '<div style=""><input type="text" class="input-desc form-control" style="width: 100%" name="descricao[' . $i . ']" value="' . PaginaSEI::tratarHTML($objMdCorServicoPostalDTO->getStrDescricao()) . '" ' . $readonly . '/><input type="hidden" name="id[' . $i . ']" value="' . $objMdCorServicoPostalDTO->getStrIdWsCorreios() . '"><input class="input-desc" type="hidden" name="codigo[' . $i . ']" value="' . trim($objMdCorServicoPostalDTO->getStrCodigoWsCorreios()) . '"><input class="input-desc" type="hidden" name="nome[' . $i . ']" value="' . $objMdCorServicoPostalDTO->getStrNome() . '"><input class="input-desc" type="hidden" value="' . $objMdCorServicoPostalDTO->getNumIdMdCorServicoPostal() . '"></div>',
                     ''
                 );
 
@@ -209,6 +214,7 @@ try {
                     $itensTabelaContratoServicos[5] = ($objMdCorServicoPostalDTO->getStrExpedicaoAvisoRecebimento() == 'S') ? 'Sim' : 'Não';
                     $itensTabelaContratoServicos[6] = ($cobrar == 'S') ? 'Sim' : 'Não';
                     $itensTabelaContratoServicos[7] = $objMdCorServicoPostalDTO->getStrDescricao();
+	                $itensTabelaContratoServicos[8] = ($anexarMidia == 'S') ? 'Sim' : 'Não';
                 }
 
                 $arrItensTabelaContratoServicos[] = $itensTabelaContratoServicos;
@@ -499,7 +505,8 @@ PaginaSEI::getInstance()->abrirAreaDados();
                                     <th class="infraTh" width="18%" id="tdDescricaoServicoPostal">Serviço Postal</th>
                                     <th class="infraTh" width="12%" align="center" id="tdCheckExpedidoAR">Tipo</th>
                                     <th class="infraTh" width="16%" align="center" id="tdCheckExpedidoAR">Expedido com AR</th>
-                                    <th class="infraTh" width="20%" align="center" id="tdCheckCobrar">Serviço à Cobrar</th>
+                                    <th class="infraTh" width="10%" align="center" id="tdCheckCobrar">Serviço à Cobrar</th>
+                                    <th class="infraTh" width="10%" align="center" id="tdCheckAnexarMidia">Permite Anexar Mídia</th>
                                     <th class="infraTh" width="22%" id="tdTxtDescricao">Descrição Amigável</th>                                    
                                     <th class="infraTh" width="7%" align="center">Ações</th>                                    
                                 </tr>

--- a/sei/web/modulos/correios/md_cor_contrato_cadastro_js.php
+++ b/sei/web/modulos/correios/md_cor_contrato_cadastro_js.php
@@ -1,18 +1,14 @@
 <script type="text/javascript">
     var comboTipoCorrepondencia = '<?php echo json_encode($mdCorTipoCorrespondencia);?>'
-    var tabelaDinamicaEditar = <? echo ($_GET['acao'] == 'md_cor_contrato_alterar' || $_GET['acao'] == 'md_cor_contrato_cadastrar') ? 'true' : 'false';  ?>;
+    var tabelaDinamicaEditar = <?= in_array( $_GET['acao'] , ['md_cor_contrato_alterar','md_cor_contrato_cadastrar'] ) ? 'true' : 'false'?>;
 
-    var tabelaDinamicaRemover = <? echo ($_GET['acao'] == 'md_cor_contrato_alterar') ? 'true' : 'false'; ?>;
+    var tabelaDinamicaRemover = <?= in_array( $_GET['acao'] , ['md_cor_contrato_alterar','md_cor_contrato_cadastrar'] ) ? 'true' : 'false' ?>;
 
-    /*
-    Variáveis usadas para montar o array de servições desativados
-     */
+    /* Variáveis usadas para montar o array de servições desativados */
     var arrLinhasDesativadas = Array();
     var arrLinhasReativadas = Array();
     var contadorDesativadas = 0;
     var contadorReativadas = 0;
-    /*
-     */
 
     <? require_once('md_cor_contrato_cadastro_inicializacao.php');?>
 
@@ -60,7 +56,8 @@
             rowRdN = '<div class="infraRadioDiv"><input class="infraRadioInput input-ar" type="radio" value="N" name="ar[' + indice + ']" id="arN[' + indice + ']" checked="checked"><label class="infraRadioLabel" for="arN['+ indice +']"></label></div><label id="lblArN['+ indice +']" for="arN['+ indice +']" class="infraLabelRadio" tabindex="<?= PaginaSEI::getInstance()->getProxTabDados() ?>">Não</label>';
             row.check = divIniRadio + rowRdS + rowRdN + '</div>';
             row.cobrar = divIniCheck + '<input class="input-cobrar infraCheckboxInput" type="checkbox" value="S" name="cobrar[' + indice + ']" id="cobrar[' + indice + ']"><label class="infraCheckboxLabel " for="cobrar['+ indice +']"></label></div></div>';
-            row.txt = '<div style="width:130px"><input class="input-desc form-control" type="text" name="descricao[' + indice + ']" value=""><input type="hidden" name="id[' + indice + ']" value="' + $(val).find('Id').text() + '"><input class="input-desc" type="hidden" name="codigo[' + indice + ']" value="' + $(val).find('Codigo').text() + '"><input class="input-desc" type="hidden" name="nome[' + indice + ']" value="' + $(val).find('Descricao').text() + '"></div>';
+            row.anexarMidia = '<div class="infraDivCheckbox" style="text-align: center"> <div class="infraCheckboxDiv"> <input type="checkbox" class="infraCheckboxInput" value="S" name="anexarMidia['+indice+']" id="anexarMidia['+indice+']"> <label class="infraCheckboxLabel" for="anexarMidia['+indice+']"></label> </div> </div>';
+            row.txt = '<div style=""><input type="text" class="input-desc form-control" style="width: 100%" name="descricao[' + indice + ']" value=""><input type="hidden" name="id[' + indice + ']" value="' + $(val).find('Id').text() + '"><input class="input-desc" type="hidden" name="codigo[' + indice + ']" value="' + $(val).find('Codigo').text() + '"><input class="input-desc" type="hidden" name="nome[' + indice + ']" value="' + $(val).find('Descricao').text() + '"></div>';
             row.acoes = 'Ações';
             var bolContratoServicosCustomizado = 'hdnCustomizado';
 
@@ -71,7 +68,7 @@
     function receberContratoServicos(row, ContratoServicosCustomizado) {
         var qtdContratoServicosIndicados = objTabelaContratoServicos.tbl.rows.length;
         objTabelaContratoServicos.exibirMensagens = false;
-        objTabelaContratoServicos.adicionar([row.id, row.codigo, row.ar, row.desc, row.nome, row.tipo, row.check, row.cobrar, row.txt, ''], false);
+        objTabelaContratoServicos.adicionar([row.id, row.codigo, row.ar, row.desc, row.nome, row.tipo, row.check, row.cobrar, row.anexarMidia, row.txt, ''], false);
         infraEfeitoTabelas();
     }
 
@@ -137,10 +134,10 @@
         var tabela = document.getElementById('tbContratoServicos');
         var arrAux = Array();
 
-        for (i = 1; i < tabela.rows.length; i++) {
+        for (let i = 1; i < tabela.rows.length; i++) {
 
             var linha = tabela.rows[i];
-            var coluna = tabela.rows[i].cells[9];
+            var coluna = tabela.rows[i].cells[10];
             var dirImg = '<?= PaginaSEI::getInstance()->getDiretorioSvgGlobal() ?>';
 
 

--- a/sei/web/modulos/correios/md_cor_expedicao_plp_lista.php
+++ b/sei/web/modulos/correios/md_cor_expedicao_plp_lista.php
@@ -78,7 +78,7 @@ $arrObjMdCorExpedicaoSolicitadaDTO->retTodos();
 
 ?>
 <form id="frmPlpGerada" method="post" action="<?=PaginaSEI::getInstance()->formatarXHTML(SessaoSEI::getInstance()->assinarLink('controlador.php?acao='. $_GET['acao'] . '&acao_origem=' . $_GET['acao']))?>">
-aaa<div style="float: left">
+<div style="float: left">
     <div style="float: left">
         <div style="float: left">
             <label>Identificador da PLP:</label></br>

--- a/sei/web/modulos/correios/md_cor_expedicao_solicitada_devolver.php
+++ b/sei/web/modulos/correios/md_cor_expedicao_solicitada_devolver.php
@@ -186,6 +186,7 @@ try {
 }
 
 ?>
+    <div id="divTituloModal" class="infraBarraLocalizacao"><?= $strTitulo ?></div>
     <form id="frmDevolverExpedicao" method="post" action="<?= $strAcaoForm ?>">
         <?php PaginaSEI::getInstance()->abrirAreaDados(); ?>
         <?php $idMdCorEexpedicaoSolicitada = isset($_GET['id_md_cor_expedicao_solicitada']) ? $_GET['id_md_cor_expedicao_solicitada'] : ''; ?>

--- a/sei/web/modulos/correios/md_cor_extensao_midia_cadastro.php
+++ b/sei/web/modulos/correios/md_cor_extensao_midia_cadastro.php
@@ -165,7 +165,7 @@ PaginaSEI::getInstance()->abrirBody($strTitulo, 'onload="inicializar();"');
         <div class="row linha">
             <div class="col-sm-10 col-md-9 col-lg-7">
                 <label id="lblPrincipal" for="txtPrincipal" accesskey="P" class="infraLabelObrigatorio">
-                    Extensões Permitidas de Arquivos para Gravação em Mídia:
+                    Extensões de Arquivos que somente aceitam Anexar Mídia:
                 </label>
                 <input type="text" id="txtPrincipal" name="txtPrincipal" class="infraText form-control"
                         onkeypress="return infraMascaraTexto(this,event,50);" maxlength="50"

--- a/sei/web/modulos/correios/md_cor_geracao_plp_lista.php
+++ b/sei/web/modulos/correios/md_cor_geracao_plp_lista.php
@@ -159,6 +159,7 @@ PaginaSEI::getInstance()->montarBarraComandosSuperior($arrComandos);
                                         $strResultado .= '<th class="infraTh" width="20%">Processo</th>';
                                         $strResultado .= '<th class="infraTh">Destinatário</th>';
                                         $strResultado .= '<th class="infraTh" width="5%">Anexo</th>';
+                                        $strResultado .= '<th class="infraTh" width="5%">Gravação em Mídia</th>';
                                         $strResultado .= '<th class="infraTh" width="10%">Ação</th>';
                                         $strResultado .= '</tr>';
 
@@ -175,6 +176,7 @@ PaginaSEI::getInstance()->montarBarraComandosSuperior($arrComandos);
                                             $strPlpTr .= '<td style="text-align: center;">' . $dadosTabela['processo'] . '</td>';
                                             $strPlpTr .= '<td>' . $dadosTabela['destinatario'] . '</td>';
                                             $strPlpTr .= '<td style="text-align: center;">' . $dadosTabela['qtdAnexo'] . '</td>';
+	                                        $strPlpTr .= '<td style="text-align: center;">' . $dadosTabela['formatoMidia'] . '</td>';
                                             $url = SessaoSEI::getInstance()->assinarLink('controlador.php?acao=md_cor_plp_selecionar_tipo_objeto&acao_origem=' . $_GET['acao'] . '&acao_retorno=' . $_GET['acao'] . '&id_md_cor_expedicao_solicitada=' . $dadosTabela['IdMdCorExpedicaoSolicitada']);
                                             $strPlpTr .= '<td style="text-align: center;"><a onclick="abrirModalSelecionarTipoObjeto(\'' . $url . '\')"><img src="modulos/correios/imagens/svg/enviar_envelope.svg?'.Icone::VERSAO.'" title="Selecionar Formato de Expedição do Objeto" alt="Selecionar Formato de Expedição do Objeto" class="infraImgAcoes"/></a>';
                                             $strPlpTr .= '<a href="' . PaginaSEI::getInstance()->formatarXHTML(SessaoSEI::getInstance()->assinarLink('controlador.php?acao=md_cor_expedicao_solicitada_consultar&acao_origem=' . $_GET['acao'] . '&acao_retorno=' . $_GET['acao'] . '&id_md_cor_expedicao_solicitada=' . $dadosTabela['IdMdCorExpedicaoSolicitada'])) . '" tabindex="' . PaginaSEI::getInstance()->getProxTabTabela() . '"><img src="' . PaginaSEI::getInstance()->getDiretorioSvgGlobal() . '/consultar.svg" title="Consultar Solicitação de Expedição" alt="Consultar Solicitação de Expedição" class="infraImg" /></a>';

--- a/sei/web/modulos/correios/md_cor_plp_imprimir_ar.php
+++ b/sei/web/modulos/correios/md_cor_plp_imprimir_ar.php
@@ -107,6 +107,8 @@ $count = 0;
     $mdCorContatoDTO->retStrCep();
     $mdCorContatoDTO->retStrNomeCidade();
     $mdCorContatoDTO->retStrSiglaUf();
+	$mdCorContatoDTO->retStrExpressaoTratamentoCargo();
+	$mdCorContatoDTO->retStrExpressaoCargo();
     $mdCorContatoDTO->setNumIdContato($objExpSolicDTO->getNumIdContatoDestinatario());
     $mdCorContatoDTO->setNumIdMdCorExpedicaoSolicitada($objExpSolicDTO->getNumIdMdCorExpedicaoSolicitada());
 
@@ -119,6 +121,8 @@ $count = 0;
         $nome .= '<br>' . $arrMdCorContatoDTO->getStrNomeContatoAssociado();
     }
 
+	$tratamento = $arrMdCorContatoDTO->getStrExpressaoTratamentoCargo();
+	$cargo      = $arrMdCorContatoDTO->getStrExpressaoCargo();
     $endereco = ($objExpSolicDTO->getStrSinEnderecoAssociado() != 'S') ? $objExpSolicDTO->getStrEnderecoDestinatario() : $arrMdCorContatoDTO->getStrEndereco();
     $complemento = ($objExpSolicDTO->getStrSinEnderecoAssociado() != 'S') ? $objExpSolicDTO->getStrComplementoDestinatario() : $arrMdCorContatoDTO->getStrComplemento();
     $bairro = ($objExpSolicDTO->getStrSinEnderecoAssociado() != 'S') ? $objExpSolicDTO->getStrBairroDestinatario() : $arrMdCorContatoDTO->getStrBairro();
@@ -199,9 +203,24 @@ $count = 0;
                     <tr>
                         <td class="pd-0">
                             <p><b>DESTINATÁRIO:</b></p>
+	                        <?php if (!empty($tratamento)):?>
+                              <p><?= trim($tratamento) ?></p>
+	                        <?php endif; ?>
+
                             <p><?= trim($nome) ?></p>
-                            <p><?= $endereco ?>, <?= $complemento ?></p>
-                            <p><?= $bairro ?></p>
+
+	                        <?php if( !empty($cargo)): ?>
+                              <p><?= trim($cargo) ?></p>
+	                        <?php endif; ?>
+
+                            <p>
+                              <?php
+                                  $strEndCompleto = trim($endereco);
+                                  $strEndCompleto .= !empty($complemento) ? ', ' . trim($complemento) : '';
+                                  $strEndCompleto .= ', ' . trim($bairro);
+                                  echo $strEndCompleto;
+                              ?>
+                            </p>
                             <p><?= $cep ?> - <?= $cidade . '/' . $uf ?></p>
                             <p style='text-indent: 67px; padding-top: 10px'><b><?= $objExpSolicDTO->getStrCodigoRastreamento() ?></b></p>
                             <p><img src="data:image/png;base64,<?= MdCorExpedicaoSolicitadaINT::montarCodigoBarra($objExpSolicDTO->getStrCodigoRastreamento(), InfraCodigoBarras::$TIPO_CODE128) ?>"/></p>

--- a/sei/web/modulos/correios/md_cor_plp_imprimir_rotulo_envelope.php
+++ b/sei/web/modulos/correios/md_cor_plp_imprimir_rotulo_envelope.php
@@ -111,9 +111,8 @@ PaginaSEI::getInstance()->abrirAreaDados();
 $count = 0;
 ?>
 
-<? foreach ($arrObjMdCorExpedicaoSolicitadaDTO
-            as $objExpSolicDTO): ?>
-<?
+<? foreach ($arrObjMdCorExpedicaoSolicitadaDTO as $objExpSolicDTO):
+
 $mdCorContatoDTO = new MdCorContatoDTO();
 $mdCorContatoDTO->retNumIdContatoAssociado();
 $mdCorContatoDTO->retStrNomeContatoAssociado();
@@ -123,6 +122,8 @@ $mdCorContatoDTO->retStrBairro();
 $mdCorContatoDTO->retStrCep();
 $mdCorContatoDTO->retStrNomeCidade();
 $mdCorContatoDTO->retStrSiglaUf();
+$mdCorContatoDTO->retStrExpressaoTratamentoCargo();
+$mdCorContatoDTO->retStrExpressaoCargo();
 $mdCorContatoDTO->setNumIdContato($objExpSolicDTO->getNumIdContatoDestinatario());
 $mdCorContatoDTO->setNumIdMdCorExpedicaoSolicitada($objExpSolicDTO->getNumIdMdCorExpedicaoSolicitada());
 
@@ -135,6 +136,8 @@ if (!empty($arrMdCorContatoDTO->getStrNomeContatoAssociado()) && ($objExpSolicDT
     $nome .= '<br>' . $arrMdCorContatoDTO->getStrNomeContatoAssociado();
 }
 
+$tratamento = $arrMdCorContatoDTO->getStrExpressaoTratamentoCargo();
+$cargo      = $arrMdCorContatoDTO->getStrExpressaoCargo();
 $endereco = ($objExpSolicDTO->getStrSinEnderecoAssociado() != 'S') ? $objExpSolicDTO->getStrEnderecoDestinatario() : $arrMdCorContatoDTO->getStrEndereco();
 $complemento = ($objExpSolicDTO->getStrSinEnderecoAssociado() != 'S') ? $objExpSolicDTO->getStrComplementoDestinatario() : $arrMdCorContatoDTO->getStrComplemento();
 $bairro = ($objExpSolicDTO->getStrSinEnderecoAssociado() != 'S') ? $objExpSolicDTO->getStrBairroDestinatario() : $arrMdCorContatoDTO->getStrBairro();
@@ -180,9 +183,7 @@ if ($count == 2) {
 }
 ?>
 <table style="width: 500px;">
-    <?
-    if ($objExpSolicDTO->getStrTipoRotuloImpressaoObjeto() == MdCorObjetoRN::$ROTULO_RESUMIDO):
-    ?>
+    <?php if ($objExpSolicDTO->getStrTipoRotuloImpressaoObjeto() == MdCorObjetoRN::$ROTULO_RESUMIDO): ?>
     <tr>
         <td>
             <div style="margin-top:<?= str_replace(',', '.', $objExpSolicDTO->getDblMargemSuperiorImpressaoObjeto()) ?>cm;display: block;width: 450px;margin-left: <?= str_replace(',', '.', $objExpSolicDTO->getDblMargemEsquerdaImpressaoObjeto()) ?>cm;margin-bottom: 25px;height: 8.4cm;<?= $style ?> ">
@@ -243,10 +244,24 @@ if ($count == 2) {
                              style="height: 1.8cm;width: 4cm;"/>
                     </div>
                     <div style="width: 229px;position: relative;top: -7px;">
+                        <?php if (!empty($tratamento)):?>
+                            <p style="text-align: left" class="font-8"><?= trim($tratamento) ?></p>
+                        <?php endif; ?>
 
                         <p style="text-align: left" class="font-8"><?= trim($nome) ?></p>
-                        <p style="text-align: left" class="font-8"><?= $endereco ?>, <?= $complemento ?></p>
-                        <p style="text-align: left" class="font-8"><?= $bairro ?></p>
+
+                        <?php if( !empty($cargo)): ?>
+                            <p style="text-align: left" class="font-8"><?= trim($cargo) ?></p>
+                        <?php endif; ?>
+
+                        <p style="text-align: left" class="font-8">
+                          <?php
+                              $strEndCompleto = trim($endereco);
+                              $strEndCompleto .= !empty($complemento) ? ', ' . trim($complemento) : '';
+                              $strEndCompleto .= ', ' . trim($bairro);
+                              echo $strEndCompleto;
+                          ?>
+                        </p>
                         <p style="text-align: left" class="font-8"><b><?= $cep ?></b> <?= $cidade . '-' . $uf ?></p>
                     </div>
                 </div>
@@ -264,7 +279,7 @@ if ($count == 2) {
                 </div>
             </div>
 
-            <? else: ?>
+    <? else: ?>
 
                 <div style="display: block;width: 400px;margin-left: <?= str_replace(',', '.', $objExpSolicDTO->getDblMargemEsquerdaImpressaoObjeto()) ?>cm;margin-top:0.5cm;">
                     <div style="max-width: 10.5cm; width: 10.5cm; padding: 0.2cm 0.5cm;border: 1px solid #000;">
@@ -319,11 +334,26 @@ if ($count == 2) {
                             </div>
                         </div>
                         <div style="width: 100%;line-height: 1.2;">
+	                        <?php if (!empty($tratamento)): ?>
+                              <p style="text-align: left" class="font-11"><?= trim($tratamento) ?></p>
+	                        <?php endif; ?>
+
                             <p style="text-align: left" class="font-11"><?= trim($nome) ?></p>
-                            <p style="text-align: left" class="font-11"><?= $endereco ?>
-                                , <?= $objExpSolicDTO->getStrComplementoDestinatario() ?></p>
-                            <p style="text-align: left" class="font-11"><?= $bairro ?></p>
-                            <p style="text-align: left" class="font-11"><b><?= $cep ?></b> <?= $cidade . '-' . $uf ?>
+
+	                        <?php if( !empty($cargo)): ?>
+                              <p style="text-align: left" class="font-11"><?= trim($cargo) ?></p>
+	                        <?php endif; ?>
+
+                            <p style="text-align: left" class="font-11">
+                                <?php
+                                    $strEndCompleto = trim($endereco);
+                                    $strEndCompleto .= !empty($objExpSolicDTO->getStrComplementoDestinatario()) ? ', ' . trim($objExpSolicDTO->getStrComplementoDestinatario()) : '';
+                                    $strEndCompleto .= ', ' . trim($bairro);
+                                    echo $strEndCompleto;
+                                ?>
+                            </p>
+                            <p style="text-align: left" class="font-11">
+                                <b><?= $cep ?></b> <?= $cidade . '-' . $uf ?>
                             </p>
                         </div>
                         <div>

--- a/sei/web/modulos/correios/rn/MdCorContratoRN.php
+++ b/sei/web/modulos/correios/rn/MdCorContratoRN.php
@@ -138,6 +138,8 @@ class MdCorContratoRN extends InfraRN
             $objMdCorServicoPostalRN = new MdCorServicoPostalRN();
             foreach ($arr['ar'] as $i => $ar) {
                 $cobrar = isset($arr['cobrar'][$i]) ? $arr['cobrar'][$i] : 'N';
+                $anexarMidia = isset($arr['anexarMidia'][$i]) ? $arr['anexarMidia'][$i] : 'N';
+
                 $objMdCorServicoPostalDTO = new MdCorServicoPostalDTO();
                 $objMdCorServicoPostalDTO->setNumIdMdCorContrato($objMdCorContratoDTO->getNumIdMdCorContrato());
                 $objMdCorServicoPostalDTO->setStrIdWsCorreios($arr['id'][$i]);
@@ -147,6 +149,7 @@ class MdCorContratoRN extends InfraRN
                 $objMdCorServicoPostalDTO->setStrDescricao($arr['descricao'][$i]);
                 $objMdCorServicoPostalDTO->setStrSinAtivo('S');
                 $objMdCorServicoPostalDTO->setStrSinServicoCobrar($cobrar);
+                $objMdCorServicoPostalDTO->setStrSinAnexarMidia($anexarMidia);
                 $objMdCorContratoDTO->setNumNumeroCnpj(InfraUtil::retirarFormatacao($arr['txtCNPJ']));
                 $objMdCorContratoDTO->setStrUsuario($arr['txtUsuario']);
                 $objMdCorContratoDTO->setStrSenha($arr['txtSenha']);
@@ -244,6 +247,8 @@ class MdCorContratoRN extends InfraRN
             }
             foreach ($arr['id'] as $i => $ar) {
                 $cobrar = isset($arr['cobrar'][$i]) ? $arr['cobrar'][$i] : 'N';
+                $anexarMidia = isset($arr['anexarMidia'][$i]) ? $arr['anexarMidia'][$i] : 'N';
+
                 $objMdCorServicoPostalDTO = new MdCorServicoPostalDTO();
                 $objMdCorServicoPostalDTO->setNumIdMdCorContrato($arr['hdnIdMdCorContrato']);
                 $objMdCorServicoPostalDTO->setStrIdWsCorreios($arr['id'][$i]);
@@ -251,6 +256,7 @@ class MdCorContratoRN extends InfraRN
                 $objMdCorServicoPostalDTO->setStrNome($arr['nome'][$i]);
                 $objMdCorServicoPostalDTO->setStrDescricao($arr['descricao'][$i]);
                 $objMdCorServicoPostalDTO->setStrSinServicoCobrar($cobrar);
+                $objMdCorServicoPostalDTO->setStrSinAnexarMidia($anexarMidia);
 
                 $arrTipoCorrespondencia = explode('|', $arr['sl_tipo'][$i]);
                 $tipoCorrespondencia = current($arrTipoCorrespondencia);
@@ -292,6 +298,7 @@ class MdCorContratoRN extends InfraRN
                 $arrIdParaAtualizar[$j]->setStrExpedicaoAvisoRecebimento($arrIdServicoPostalPost[$j]->getStrExpedicaoAvisoRecebimento());
                 $arrIdParaAtualizar[$j]->setStrDescricao($arrIdServicoPostalPost[$j]->getStrDescricao());
                 $arrIdParaAtualizar[$j]->setStrSinServicoCobrar($arrIdServicoPostalPost[$j]->getStrSinServicoCobrar());
+                $arrIdParaAtualizar[$j]->setStrSinAnexarMidia($arrIdServicoPostalPost[$j]->getStrSinAnexarMidia());
                 $arrIdParaAtualizar[$j]->setNumIdMdCorTipoCorrespondencia($arrIdServicoPostalPost[$j]->getNumIdMdCorTipoCorrespondencia());
                 $objMdCorServicoPostalRN->alterar($objMdCorServicoPostalDTO);
             }

--- a/sei/web/modulos/correios/rn/MdCorExpedicaoSolicitadaRN.php
+++ b/sei/web/modulos/correios/rn/MdCorExpedicaoSolicitadaRN.php
@@ -156,7 +156,9 @@ class MdCorExpedicaoSolicitadaRN extends InfraRN
                     $itemDTO->setStrNomeCidade($arrObjContatoDTO->getStrNomeCidadeContatoAssociado());
                     $itemDTO->setStrSiglaUf($arrObjContatoDTO->getStrSiglaUfContatoAssociado());
                 } else {
-                    $itemDTO->setNumIdContatoAssociado($arrObjContatoDTO->getNumIdContato());
+                    $itemDTO->setNumIdContatoAssociado($arrObjContatoDTO->getNumIdContatoAssociado());
+	                  $itemDTO->setStrNomeContatoAssociado($arrObjContatoDTO->getStrNomeContatoAssociado());
+	                  $itemDTO->setStrStaNaturezaContatoAssociado($arrObjContatoDTO->getStrStaNaturezaContatoAssociado());
                     $itemDTO->setStrEndereco($arrObjContatoDTO->getStrEndereco());
                     $itemDTO->setStrComplemento($arrObjContatoDTO->getStrComplemento());
                     $itemDTO->setStrBairro($arrObjContatoDTO->getStrBairro());
@@ -612,17 +614,18 @@ class MdCorExpedicaoSolicitadaRN extends InfraRN
             $strDestinatario = "";
 
             $strDestinatario .= mb_strtoupper($objMdCorContatoDTO->getStrNome(), 'ISO-8859-1') . "<br />";
-            if ($objMdCorContatoDTO->getStrSinEnderecoAssociado() == 'S') {
+            $strDestinatario .= !empty($objMdCorContatoDTO->getStrExpressaoCargo()) ? $objMdCorContatoDTO->getStrExpressaoCargo() . "<br />" : '';
+            if ( !empty($objMdCorContatoDTO->getStrNomeContatoAssociado()) && $objMdCorContatoDTO->getNumIdContato() != $objMdCorContatoDTO->getNumIdContatoAssociado() ) {
                 $strDestinatario .= $objMdCorContatoDTO->getStrNomeContatoAssociado() . "<br />";
             }
-            $strDestinatario .= $objMdCorContatoDTO->getStrNomeTipoContato() . "<br />";
-            if ($objMdCorContatoDTO->getStrSinEnderecoAssociado() == 'S') {
-                $strDestinatario .= $objMdCorContatoDTO->getStrNomeCidadeContatoAssociado() . "/";
-                $strDestinatario .= $objMdCorContatoDTO->getStrSiglaUfContatoAssociado() . "<br />";
-            } else {
-                $strDestinatario .= $objMdCorContatoDTO->getStrNomeCidade() . "/";
-                $strDestinatario .= $objMdCorContatoDTO->getStrSiglaUf() . "<br />";
-            }
+            //$strDestinatario .= $objMdCorContatoDTO->getStrNomeTipoContato() . "<br />"; #removido para padronizar os dados do destinatario
+	          // monta a parte do endereco
+	          $strEndereco = $objMdCorContatoDTO->getStrEndereco();
+            $strCompl    = $objMdCorContatoDTO->getStrComplemento() ? ', ' . $objMdCorContatoDTO->getStrComplemento() : '';
+            $strBairro   = $objMdCorContatoDTO->getStrBairro();
+
+	          $strDestinatario .= "$strEndereco $strCompl , $strBairro <br />";
+	          $strDestinatario .= "{$objMdCorContatoDTO->getStrCep()} - {$objMdCorContatoDTO->getStrNomeCidade()}/{$objMdCorContatoDTO->getStrSiglaUf()} <br />";
 
             $id = $objItemDto->getNumIdMdCorExpedicaoSolicitada();
             $arrSolExpedicao[$objItemDto->getStrDescricaoServicoPostal()][$contadorFor]['IdMdCorExpedicaoSolicitada'] = $id;
@@ -639,6 +642,16 @@ class MdCorExpedicaoSolicitadaRN extends InfraRN
             $arrSolExpedicao[$objItemDto->getStrDescricaoServicoPostal()][$contadorFor]['destinatario'] = $strDestinatario;
             //Retirando o documento principal, para que não seja identificado como anexo
             $arrSolExpedicao[$objItemDto->getStrDescricaoServicoPostal()][$contadorFor]['qtdAnexo'] = $arrAnexo[$id] - 1;
+
+            /* Verifica se existe alguma solicitacao em Midia para cada expedicao */
+	          $objMdCorExpedicaoFormatoDTO = new MdCorExpedicaoFormatoDTO();
+	          $objMdCorExpedicaoFormatoDTO->setNumIdMdCorExpedicaoSolicitada($id);
+	          $objMdCorExpedicaoFormatoDTO->setStrFormaExpedicao('M');
+
+	          $qtd = ( new MdCorExpedicaoFormatoRN() )->contar( $objMdCorExpedicaoFormatoDTO );
+
+	          if ( $qtd > 0 ) $arrSolExpedicao[$objItemDto->getStrDescricaoServicoPostal()][$contadorFor]['formatoMidia'] = 'Sim';
+	          else $arrSolExpedicao[$objItemDto->getStrDescricaoServicoPostal()][$contadorFor]['formatoMidia'] = 'Não';
 
             $contadorFor++;
 

--- a/sip/scripts/sip_atualizar_versao_modulo_correios.php
+++ b/sip/scripts/sip_atualizar_versao_modulo_correios.php
@@ -5,10 +5,10 @@ class MdCorAtualizadorSipRN extends InfraRN
 {
 
     private $numSeg = 0;
-    private $versaoAtualDesteModulo = '2.1.0';
+    private $versaoAtualDesteModulo = '2.2.0';
     private $nomeDesteModulo = 'MÓDULO DOS CORREIOS';
     private $nomeParametroModulo = 'VERSAO_MODULO_CORREIOS';
-    private $historicoVersoes = array('1.0.0', '2.0.0', '2.1.0');
+    private $historicoVersoes = array('1.0.0', '2.0.0', '2.1.0','2.2.0');
 
     public function __construct()
     {
@@ -114,6 +114,8 @@ class MdCorAtualizadorSipRN extends InfraRN
                     $this->instalarv200();
                 case '2.0.0':
                     $this->instalarv210();
+	              case '2.1.0':
+		                $this->instalarv220();
                     break;
 
                 default:
@@ -628,7 +630,7 @@ class MdCorAtualizadorSipRN extends InfraRN
         $this->logar('ADICIONANDO PARÂMETRO ' . $this->nomeParametroModulo . ' NA TABELA infra_parametro PARA CONTROLAR A VERSÃO DO MÓDULO');
         BancoSip::getInstance()->executarSql('INSERT INTO infra_parametro (valor, nome) VALUES(\'1.0.0\',   \'' . $this->nomeParametroModulo . '\' )');
 
-        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO ' . $this->versaoAtualDesteModulo . ' DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SIP');
+        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO 1.0.0 DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SIP');
     }
 
     protected function instalarv200()
@@ -648,7 +650,7 @@ class MdCorAtualizadorSipRN extends InfraRN
         $this->logar('ATUALIZANDO PARÂMETRO ' . $this->nomeParametroModulo . ' NA TABELA infra_parametro PARA CONTROLAR A VERSÃO DO MÓDULO');
         BancoSip::getInstance()->executarSql('UPDATE infra_parametro SET valor = \'2.0.0\' WHERE nome = \'' . $this->nomeParametroModulo . '\' ');
 
-        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO ' . $this->versaoAtualDesteModulo . ' DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SIP');
+        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO 2.0.0 DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SIP');
     }
 
     protected function instalarv210()
@@ -683,8 +685,18 @@ class MdCorAtualizadorSipRN extends InfraRN
         $this->logar('ATUALIZANDO PARÂMETRO ' . $this->nomeParametroModulo . ' NA TABELA infra_parametro PARA CONTROLAR A VERSÃO DO MÓDULO');
         BancoSip::getInstance()->executarSql('UPDATE infra_parametro SET valor = \'2.1.0\' WHERE nome = \'' . $this->nomeParametroModulo . '\' ');
 
-        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO ' . $this->versaoAtualDesteModulo . ' DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SIP');
+        $this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO 2.1.0 DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SIP');
     }
+
+		protected function instalarv220()
+		{
+			$this->logar('EXECUTANDO A INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO 2.2.0 DO ' . $this->nomeDesteModulo . ' NA BASE DO SIP');
+
+			$this->logar('ATUALIZANDO PARÂMETRO ' . $this->nomeParametroModulo . ' NA TABELA infra_parametro PARA CONTROLAR A VERSÃO DO MÓDULO');
+			BancoSip::getInstance()->executarSql('UPDATE infra_parametro SET valor = \'2.2.0\' WHERE nome = \'' . $this->nomeParametroModulo . '\' ');
+
+			$this->logar('INSTALAÇÃO/ATUALIZAÇÃO DA VERSÃO 2.2.0 DO ' . $this->nomeDesteModulo . ' REALIZADA COM SUCESSO NA BASE DO SIP');
+		}
 
     private function adicionarRecursoPerfil($numIdSistema, $numIdPerfil, $strNome, $strCaminho = null)
     {


### PR DESCRIPTION
## Correções desta Versão
1.	Padronizada a exibição dos dados do Destinatário nas telas de Solicitação de Expedição, Gerar PLP e nas Impressões de envelope e AR.
2.	Corrigida a exibição dos dados da Pessoa Jurídica associada na tela de cadastro, alteração e consulta de Solicitação de Expedição.
3.	Removida mensagem de alerta exibida indevidamente após salvar uma Solicitação de Expedição.

## Evoluções desta Versão
1.	Na Administração > Correios > Contratos e Serviços Postais, adicionada coluna de parametrização dos Serviços Postais do Contrato para sinalizar se o serviço postal “Permite Anexar Mídia”.
2.	Na Administração > Correios > Extensões para Gravação em Mídia, ajustado o nome do único campo da tela para deixar a finalidade do campo mais claramente, que é para indicação das “Extensões de Arquivos que somente aceitam Anexar Mídia”.
3.	Com os dois ajustes acima na Administração do SEI Correios, na tela do usuário “Solicitar Expedição pelos Correios” foram adicionadas críticas para somente deixar indicar “Anexos” envolvendo Documento Externo de arquivos com extensão que somente aceitam gravação de mídia (arquivos que não dá para imprimir) se o “Serviço Postal” escolhido pelo usuário tiver a marcação de que “Permite Anexar Mídia”.