### PR TITLE
atualização do script de instalação para corrigir falha de não popular md_cor_lista_status

### DIFF
--- a/sei/scripts/sei_atualizar_versao_modulo_correios.php
+++ b/sei/scripts/sei_atualizar_versao_modulo_correios.php
@@ -502,6 +502,7 @@ class MdCorAtualizadorSeiRN extends InfraRN
             foreach ($dados as $tipo => $dado) {
                 foreach ($dado as $desc => $nomeImagem) {
                     BancoSEI::getInstance()->executarSql("INSERT INTO md_cor_lista_status (id_md_cor_lista_status, status, tipo, nome_imagem, descricao, sin_ativo) VALUES('".$numMdCorListaStatus."', '".$status."', '".$tipo."', '".$nomeImagem."', '".$desc."', 'S')");
+                    BancoSEI::getInstance()->executarSql("INSERT INTO seq_md_cor_lista_status (id, campo) VALUES('".$numMdCorListaStatus."', '0')");
                     $numMdCorListaStatus++;
                 }
             }


### PR DESCRIPTION
Em uma versão do correios uma coluna na tabela md_cor_lista_status deixou de exisitir mas o script de instalação precisava da colula preenchida para posteriormente utilizar os dados contindos nela e depois excluir a mesma. Com isso a coluna não existia mapeado no DTO fazendo com que fosse necessário uma utilizar outra abordagem aonde a sequence deixou de popular na carga inicial.